### PR TITLE
serviceCall validation

### DIFF
--- a/packages/scalecube-microservice/src/ServiceCall/LocalCall.ts
+++ b/packages/scalecube-microservice/src/ServiceCall/LocalCall.ts
@@ -1,13 +1,8 @@
-import { from, throwError, Observable } from 'rxjs';
+import { from, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { throwErrorFromServiceCall } from '../helpers/utils';
 import { AddMessageToResponseOptions, InvokeMethodOptions, LocalCallOptions } from '../helpers/types';
-import {
-  getAsyncModelMissmatch,
-  getMethodNotFoundError,
-  WRONG_DATA_FORMAT_IN_MESSAGE,
-  ASYNC_MODEL_TYPES,
-} from '../helpers/constants';
+import { getAsyncModelMissmatch, getMethodNotFoundError, ASYNC_MODEL_TYPES } from '../helpers/constants';
 
 export const localCall = ({ localService, asyncModel, includeMessage, message }: LocalCallOptions): Observable<any> => {
   const { reference, asyncModel: asyncModelProvider } = localService;
@@ -18,10 +13,6 @@ export const localCall = ({ localService, asyncModel, includeMessage, message }:
       asyncModel: ASYNC_MODEL_TYPES.REQUEST_STREAM,
       errorMessage: getAsyncModelMissmatch(asyncModel, asyncModelProvider),
     }) as Observable<any>;
-  }
-
-  if (!message.data || !Array.isArray(message.data)) {
-    return throwError(new Error(WRONG_DATA_FORMAT_IN_MESSAGE));
   }
 
   return method

--- a/packages/scalecube-microservice/src/ServiceCall/ServiceCall.ts
+++ b/packages/scalecube-microservice/src/ServiceCall/ServiceCall.ts
@@ -1,7 +1,12 @@
 import { Observable } from 'rxjs';
 import { ServiceCall, CreateServiceCallOptions, ServiceCallResponse, ServiceCallOptions } from '../helpers/types';
-import { throwErrorFromServiceCall } from '../helpers/utils';
-import { MESSAGE_NOT_PROVIDED, ASYNC_MODEL_TYPES } from '../helpers/constants';
+import { isObject, isString, throwErrorFromServiceCall } from '../helpers/utils';
+import {
+  MESSAGE_NOT_PROVIDED,
+  ASYNC_MODEL_TYPES,
+  WRONG_DATA_FORMAT_IN_MESSAGE,
+  QUALIFIER_IS_NOT_STRING,
+} from '../helpers/constants';
 import { localCall } from './LocalCall';
 import { remoteCall } from './RemoteCall';
 import { take } from 'rxjs/operators';
@@ -10,8 +15,16 @@ export const getServiceCall = ({ router, microserviceContext }: CreateServiceCal
   const openConnections = {};
 
   return ({ message, asyncModel, includeMessage }: ServiceCallOptions): ServiceCallResponse => {
-    if (!message) {
+    if (!message || !isObject(message)) {
       return throwErrorFromServiceCall({ asyncModel, errorMessage: MESSAGE_NOT_PROVIDED });
+    }
+
+    if (!message.data || !Array.isArray(message.data)) {
+      return throwErrorFromServiceCall({ asyncModel, errorMessage: WRONG_DATA_FORMAT_IN_MESSAGE });
+    }
+
+    if (!message.qualifier || !isString(message.qualifier)) {
+      return throwErrorFromServiceCall({ asyncModel, errorMessage: QUALIFIER_IS_NOT_STRING });
     }
 
     const localService = microserviceContext.methodRegistry.lookUp({ qualifier: message.qualifier });

--- a/packages/scalecube-microservice/src/helpers/constants.ts
+++ b/packages/scalecube-microservice/src/helpers/constants.ts
@@ -7,6 +7,7 @@ export const SERVICE_NAME_NOT_PROVIDED = '(serviceDefinition.serviceName) is not
 export const WRONG_DATA_FORMAT_IN_MESSAGE = 'Message format error: data must be Array';
 export const DEFINITION_MISSING_METHODS = 'Definition missing methods:object';
 export const SERVICES_IS_NOT_ARRAY = 'services is not array';
+export const QUALIFIER_IS_NOT_STRING = 'qualifier not of type string';
 
 export const getServiceMethodIsMissingError = (methodName: string) =>
   `service method '${methodName}' missing in the serviceDefinition`;

--- a/packages/scalecube-microservice/tests/integration/Errors/createServiceCall.spec.ts
+++ b/packages/scalecube-microservice/tests/integration/Errors/createServiceCall.spec.ts
@@ -1,5 +1,170 @@
-describe('describe place holder', () => {
-  test('test place holder', () => {
-    expect(true).toBe(true);
-  });
+/*****
+ * This file contains scenarios for failed attempts when using serviceCall method.
+ * 1. Included validation tests for serviceCall.
+ * 2. Related issue in GitHub
+ *    Check validation - serviceCall without message - https://github.com/scalecube/scalecube-js/issues/109
+ *    Check validation - serviceCall message data is not an array - https://github.com/scalecube/scalecube-js/issues/110
+ *    Check validation - serviceCall qualifier is not type string - https://github.com/scalecube/scalecube-js/issues/111
+ *****/
+import { Microservices } from '../../../src';
+import {
+  MESSAGE_NOT_PROVIDED,
+  QUALIFIER_IS_NOT_STRING,
+  WRONG_DATA_FORMAT_IN_MESSAGE,
+} from '../../../src/helpers/constants';
+
+describe('validation test for create proxy from microservice', () => {
+  const ms = Microservices.create({});
+  const serviceCall = ms.createServiceCall({});
+
+  // @ts-ignore
+  describe.each([[], 'test', 10, null, undefined, Symbol(), true, false])(
+    `
+      Scenario: serviceCall invalid message
+      Given     invalid message
+                | type      | value     |
+                | array     | []        |
+                | string    | 'test'    |
+                | number    | 10        |
+                | null      | null      |
+                | undefined | undefined |
+                | symbol    | Symbol()  |
+                | boolean   | true      |
+                | boolean   | false     |
+      `,
+    (message) => {
+      test(`
+      Given     a serviceCall instance
+      And       message invalid format
+      When      invoking a requestResponse with invalid message
+      Then      the requestResponse will reject with error message
+    `, () => {
+        expect.assertions(1);
+        // @ts-ignore
+        return expect(serviceCall.requestResponse(message)).rejects.toMatchObject(new Error(MESSAGE_NOT_PROVIDED));
+      });
+
+      test(`
+      Given     a serviceCall instance
+      And       message invalid format
+      When      subscribe to requestStream with invalid message
+      Then      the requestStream will reject with error message
+    `, (done) => {
+        expect.assertions(1);
+        // @ts-ignore
+        serviceCall.requestStream(message).subscribe(
+          () => {},
+          (error: Error) => {
+            expect(error.message).toMatch(MESSAGE_NOT_PROVIDED);
+            done();
+          }
+        );
+      });
+    }
+  );
+
+  // @ts-ignore
+  describe.each(['test', '', 10, {}, null, undefined, Symbol(), true, false])(
+    `
+      Scenario: serviceCall invalid message - data is not array
+      Given     invalid message
+                | type      | value     |
+                | string    | 'test'    |
+                | string    | ''        |
+                | number    | 10        |
+                | null      | null      |
+                | object    | {}        |
+                | undefined | undefined |
+                | symbol    | Symbol()  |
+                | boolean   | true      |
+                | boolean   | false     |
+      `,
+    (data) => {
+      const message = {
+        qualifier: 'temp',
+        data,
+      };
+
+      test(`
+      Given     a serviceCall instance
+      And       message with invalid data format
+      When      invoking a requestResponse with invalid message
+      Then      the requestResponse will reject with error message
+    `, () => {
+        expect.assertions(1);
+        // @ts-ignore
+        return expect(serviceCall.requestResponse(message)).rejects.toMatchObject(
+          new Error(WRONG_DATA_FORMAT_IN_MESSAGE)
+        );
+      });
+
+      test(`
+      Given     a serviceCall instance
+      And       message with invalid data format
+      When      subscribe to requestStream with invalid message
+      Then      the requestStream will reject with error message
+    `, (done) => {
+        expect.assertions(1);
+        // @ts-ignore
+        serviceCall.requestStream(message).subscribe(
+          () => {},
+          (error: Error) => {
+            expect(error.message).toMatch(WRONG_DATA_FORMAT_IN_MESSAGE);
+            done();
+          }
+        );
+      });
+    }
+  );
+
+  // @ts-ignore
+  describe.each([[], 10, {}, null, undefined, Symbol(), true, false])(
+    `
+      Scenario: serviceCall invalid message - qualifier is not string
+      Given     invalid message 
+                | type      | value     |
+                | array     | []        |
+                | number    | 10        |
+                | null      | null      |
+                | object    | {}        |
+                | undefined | undefined |
+                | symbol    | Symbol()  |
+                | boolean   | true      |
+                | boolean   | false     |
+      `,
+    (qualifier) => {
+      const message = {
+        qualifier,
+        data: [],
+      };
+
+      test(`
+      Given     a serviceCall instance
+      And       message with invalid qualifier format
+      When      invoking a requestResponse with invalid message
+      Then      the requestResponse will reject with error message
+    `, () => {
+        expect.assertions(1);
+        // @ts-ignore
+        return expect(serviceCall.requestResponse(message)).rejects.toMatchObject(new Error(QUALIFIER_IS_NOT_STRING));
+      });
+
+      test(`
+      Given     a serviceCall instance
+      And       message with invalid qualifier format
+      When      subscribe to requestStream with invalid message
+      Then      the requestStream will reject with error message
+    `, (done) => {
+        expect.assertions(1);
+        // @ts-ignore
+        serviceCall.requestStream(message).subscribe(
+          () => {},
+          (error: Error) => {
+            expect(error.message).toMatch(QUALIFIER_IS_NOT_STRING);
+            done();
+          }
+        );
+      });
+    }
+  );
 });


### PR DESCRIPTION
 *    - [Check validation - serviceCall without message] (https://github.com/scalecube/scalecube-js/issues/109)
 *    - [Check validation - serviceCall message data is not an array](https://github.com/scalecube/scalecube-js/issues/110)
 *    - [Check validation - serviceCall qualifier is not type string](https://github.com/scalecube/scalecube-js/issues/111)