### PR TITLE
Multiple gateway-proxies

### DIFF
--- a/packages/api/src/microservice/Qualifier.ts
+++ b/packages/api/src/microservice/Qualifier.ts
@@ -1,0 +1,4 @@
+export interface Qualifier {
+  serviceName: string;
+  methodName: string;
+}

--- a/packages/api/src/microservice/index.ts
+++ b/packages/api/src/microservice/index.ts
@@ -10,3 +10,4 @@ export { RouterOptions, Router } from './Router';
 export { Service } from './Service';
 export { ServiceDefinition } from './ServiceDefinition';
 export { ServiceReference } from './ServiceReference';
+export { Qualifier } from './Qualifier';

--- a/packages/rsocket-ws-gateway/README.md
+++ b/packages/rsocket-ws-gateway/README.md
@@ -26,8 +26,8 @@ const definition = {
     methodA: { asyncModel: ASYNC_MODEL_TYPES.REQUEST_RESPONSE },
   },
 };
-const service = { methodA: () => Promise.resolve('ok') };
-const services = [{ definition, reference: serviceA }];
+const reference = { methodA: () => Promise.resolve('ok') };
+const services = [{ definition, reference }];
 const ms = createMicroservice({ services });
 const serviceCall = ms.createServiceCall({});
 const gateway = new Gateway({ port: 3000 });

--- a/packages/rsocket-ws-gateway/README.md
+++ b/packages/rsocket-ws-gateway/README.md
@@ -14,12 +14,38 @@ interface Gateway {
 
 # Usage
 
+## Server side
+
 ```typescript
 import { createMicroservice } from '@scalecube/scalecube-microservice';
 import { Gateway } from '@scalecube/rsocket-ws-gateway';
 
-const gateway = new Gateway({ port: 3000 });
-const ms = createMicroservice();
+const definition = {
+  serviceName: 'serviceA',
+  methods: {
+    methodA: { asyncModel: ASYNC_MODEL_TYPES.REQUEST_RESPONSE },
+  },
+};
+const service = { methodA: () => Promise.resolve('ok') };
+const services = [{ definition, reference: serviceA }];
+const ms = createMicroservice({ services });
 const serviceCall = ms.createServiceCall({});
+const gateway = new Gateway({ port: 3000 });
 gateway.start({ serviceCall });
+```
+
+## Client side
+
+```typescript
+import { createGatewayProxy } from '@scalecube/rsocket-ws-gateway/dist/createGatewayProxy';
+
+
+const definition = {
+  serviceName: 'serviceA',
+  methods: {
+    methodA: { asyncModel: ASYNC_MODEL_TYPES.REQUEST_RESPONSE },
+  },
+};
+  const proxy = await createGatewayProxy('ws://localhost:3000', definition);
+  const resp = await proxy.methodA() // => 'ok'
 ```

--- a/packages/rsocket-ws-gateway/package.json
+++ b/packages/rsocket-ws-gateway/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@scalecube/api": "^0.0.2-alpha.9",
+    "@scalecube/utils": "^0.0.2-alpha.9",
     "rsocket-core": "^0.0.10",
     "rsocket-flowable": "^0.0.10",
     "rsocket-websocket-client": "^0.0.10",

--- a/packages/rsocket-ws-gateway/src/api/createGatewayProxy.ts
+++ b/packages/rsocket-ws-gateway/src/api/createGatewayProxy.ts
@@ -1,0 +1,9 @@
+import { MicroserviceApi } from '@scalecube/api';
+
+export interface Proxy {
+  [state: string]: any;
+}
+
+type singleProxyCreator = (url: string, definition: MicroserviceApi.ServiceDefinition) => Promise<Proxy>;
+type multipleProxyCreator = (url: string, definitions: MicroserviceApi.ServiceDefinition[]) => Promise<Proxy[]>;
+export type createGatewayProxyType = singleProxyCreator | multipleProxyCreator;

--- a/packages/rsocket-ws-gateway/src/api/createGatewayProxy.ts
+++ b/packages/rsocket-ws-gateway/src/api/createGatewayProxy.ts
@@ -1,9 +1,0 @@
-import { MicroserviceApi } from '@scalecube/api';
-
-export interface Proxy {
-  [state: string]: any;
-}
-
-type singleProxyCreator = (url: string, definition: MicroserviceApi.ServiceDefinition) => Promise<Proxy>;
-type multipleProxyCreator = (url: string, definitions: MicroserviceApi.ServiceDefinition[]) => Promise<Proxy[]>;
-export type createGatewayProxyType = singleProxyCreator | multipleProxyCreator;

--- a/packages/rsocket-ws-gateway/src/createGatewayProxy.ts
+++ b/packages/rsocket-ws-gateway/src/createGatewayProxy.ts
@@ -4,6 +4,7 @@ import { RSocketClient, JsonSerializers } from 'rsocket-core';
 import { unpackError } from './utils';
 import { createGatewayProxyType, Proxy } from './api/createGatewayProxy';
 import { MicroserviceApi } from '@scalecube/api';
+import { validateServiceDefinition } from '@scalecube/utils';
 
 export const createGatewayProxy: createGatewayProxyType = (url, definitions) => {
   const isDefinitionsArray = Array.isArray(definitions);
@@ -24,6 +25,7 @@ export const createGatewayProxy: createGatewayProxyType = (url, definitions) => 
     }
     defs.forEach((definition) => {
       const { serviceName, methods } = definition;
+      validateServiceDefinition(definition);
       const proxy: Proxy = {};
       Object.keys(methods).forEach((method) => {
         const asyncModel = methods[method].asyncModel;

--- a/packages/rsocket-ws-gateway/src/createGatewayProxy.ts
+++ b/packages/rsocket-ws-gateway/src/createGatewayProxy.ts
@@ -2,7 +2,6 @@ import { Observable } from 'rxjs';
 import RSocketWebSocketClient from 'rsocket-websocket-client';
 import { RSocketClient, JsonSerializers } from 'rsocket-core';
 import { unpackError } from './utils';
-import { createGatewayProxyType, Proxy } from './api/createGatewayProxy';
 import { MicroserviceApi } from '@scalecube/api';
 import { validateServiceDefinition } from '@scalecube/utils';
 

--- a/packages/rsocket-ws-gateway/src/createGatewayProxy.ts
+++ b/packages/rsocket-ws-gateway/src/createGatewayProxy.ts
@@ -2,15 +2,18 @@ import { Observable } from 'rxjs';
 import RSocketWebSocketClient from 'rsocket-websocket-client';
 import { RSocketClient, JsonSerializers } from 'rsocket-core';
 import { unpackError } from './utils';
+import { createGatewayProxyType, Proxy } from './api/createGatewayProxy';
+import { MicroserviceApi } from '@scalecube/api';
 
-type createGatewayProxyType = (url: string, definitions: any) => Promise<any>;
-
-export const createGatewayProxy = (url, definitions) => {
+export const createGatewayProxy: createGatewayProxyType = (url, definitions) => {
   const isDefinitionsArray = Array.isArray(definitions);
+  let defs: MicroserviceApi.ServiceDefinition[];
   if (!isDefinitionsArray) {
-    definitions = [definitions];
+    defs = [definitions];
+  } else {
+    defs = definitions;
   }
-  const proxies: Array<any> = [];
+  const proxies: Proxy[] = [];
   let socket;
   return new Promise(async (resolve, reject) => {
     try {
@@ -19,9 +22,9 @@ export const createGatewayProxy = (url, definitions) => {
       // console.log('Err', e);
       reject(e);
     }
-    definitions.forEach((definition) => {
+    defs.forEach((definition) => {
       const { serviceName, methods } = definition;
-      const proxy = {};
+      const proxy: Proxy = {};
       Object.keys(methods).forEach((method) => {
         const asyncModel = methods[method].asyncModel;
         const qualifier = `${serviceName}/${method}`;

--- a/packages/rsocket-ws-gateway/src/createGatewayProxy.ts
+++ b/packages/rsocket-ws-gateway/src/createGatewayProxy.ts
@@ -6,7 +6,13 @@ import { createGatewayProxyType, Proxy } from './api/createGatewayProxy';
 import { MicroserviceApi } from '@scalecube/api';
 import { validateServiceDefinition } from '@scalecube/utils';
 
-export const createGatewayProxy: createGatewayProxyType = (url, definitions) => {
+interface Proxy {
+  [state: string]: any;
+}
+
+export function createGatewayProxy(url: string, definition: MicroserviceApi.ServiceDefinition): Promise<Proxy>;
+export function createGatewayProxy(url: string, definition: MicroserviceApi.ServiceDefinition[]): Promise<Proxy[]>;
+export function createGatewayProxy(url: string, definitions: any): any {
   const isDefinitionsArray = Array.isArray(definitions);
   let defs: MicroserviceApi.ServiceDefinition[];
   if (!isDefinitionsArray) {
@@ -46,7 +52,7 @@ export const createGatewayProxy: createGatewayProxyType = (url, definitions) => 
 
     resolve(isDefinitionsArray ? proxies : proxies[0]);
   });
-};
+}
 
 const connect = (url) => {
   return new Promise((resolve, reject) => {

--- a/packages/rsocket-ws-gateway/src/createGatewayProxy.ts
+++ b/packages/rsocket-ws-gateway/src/createGatewayProxy.ts
@@ -3,7 +3,7 @@ import RSocketWebSocketClient from 'rsocket-websocket-client';
 import { RSocketClient, JsonSerializers } from 'rsocket-core';
 import { unpackError } from './utils';
 import { MicroserviceApi } from '@scalecube/api';
-import { validateServiceDefinition } from '@scalecube/utils';
+import { validateServiceDefinition, getQualifier } from '@scalecube/utils';
 
 interface Proxy {
   [state: string]: any;
@@ -34,7 +34,7 @@ export function createGatewayProxy(url: string, definitions: any): any {
       const proxy: Proxy = {};
       Object.keys(methods).forEach((method) => {
         const asyncModel = methods[method].asyncModel;
-        const qualifier = `${serviceName}/${method}`;
+        const qualifier = getQualifier({ serviceName, methodName: method });
         proxy[method] = (() => {
           switch (asyncModel) {
             case 'requestResponse':

--- a/packages/rsocket-ws-gateway/tests/multi-proxy.spec.ts
+++ b/packages/rsocket-ws-gateway/tests/multi-proxy.spec.ts
@@ -23,10 +23,10 @@ const serviceCall = ms.createServiceCall({});
 const gateway = new Gateway({ port: 8080 });
 gateway.start({ serviceCall });
 
-let proxyA, proxyB;
+let proxyA;
+let proxyB;
 
 beforeAll(async () => {
-  // @ts-ignore
   [proxyA, proxyB] = await createGatewayProxy('ws://localhost:8080', [definitionA, definitionB]);
 });
 afterAll(() => gateway.stop());

--- a/packages/rsocket-ws-gateway/tests/multi-proxy.spec.ts
+++ b/packages/rsocket-ws-gateway/tests/multi-proxy.spec.ts
@@ -1,0 +1,44 @@
+import { createMicroservice, ASYNC_MODEL_TYPES } from '@scalecube/scalecube-microservice';
+import { Gateway } from '../src/Gateway';
+import { createGatewayProxy } from '../src/createGatewayProxy';
+
+const definitionA = {
+  serviceName: 'serviceA',
+  methods: {
+    methodA: { asyncModel: ASYNC_MODEL_TYPES.REQUEST_RESPONSE },
+  },
+};
+const definitionB = {
+  serviceName: 'serviceB',
+  methods: {
+    methodB: { asyncModel: ASYNC_MODEL_TYPES.REQUEST_RESPONSE },
+  },
+};
+const serviceA = { methodA: () => Promise.resolve('ok') };
+const serviceB = { methodB: () => Promise.resolve('bye') };
+const services = [{ definition: definitionA, reference: serviceA }, { definition: definitionB, reference: serviceB }];
+
+const ms = createMicroservice({ services });
+const serviceCall = ms.createServiceCall({});
+const gateway = new Gateway({ port: 8080 });
+gateway.start({ serviceCall });
+
+let proxyA, proxyB;
+
+beforeAll(async () => {
+  // @ts-ignore
+  [proxyA, proxyB] = await createGatewayProxy('ws://localhost:8080', [definitionA, definitionB]);
+});
+afterAll(() => gateway.stop());
+
+test(`Given microservices with gateway
+    And   two service 
+    And   two gateway-proxies created simultanously by createGatewayProxy method
+    When  two requests executed through those proxies
+    Then  two success responses returned by both of proxies`, async () => {
+  const respA = await proxyA.methodA();
+  expect(respA).toEqual('ok');
+  const respB = await proxyB.methodB();
+  expect(respB).toEqual('bye');
+  gateway.stop();
+});

--- a/packages/scalecube-microservice/src/Proxy/createProxy.ts
+++ b/packages/scalecube-microservice/src/Proxy/createProxy.ts
@@ -1,7 +1,7 @@
 import { TransportApi, MicroserviceApi } from '@scalecube/api';
 import { MicroserviceContext } from '../helpers/types';
 import { DUPLICATE_PROXY_NAME, MICROSERVICE_NOT_EXISTS } from '../helpers/constants';
-import { validateServiceDefinition } from '../helpers/validation';
+import { validateServiceDefinition } from '@scalecube/utils';
 import { getProxy } from './Proxy';
 import { getServiceCall } from '../ServiceCall/ServiceCall';
 import { defaultRouter } from '../Routers/default';

--- a/packages/scalecube-microservice/src/helpers/constants.ts
+++ b/packages/scalecube-microservice/src/helpers/constants.ts
@@ -1,5 +1,7 @@
 import { MicroserviceApi } from '@scalecube/api';
+import { constants } from '@scalecube/utils';
 
+export const { ASYNC_MODEL_TYPES } = constants;
 export const MICROSERVICE_NOT_EXISTS = 'microservice does not exists';
 export const MESSAGE_NOT_PROVIDED = 'Message has not been provided';
 export const MESSAGE_DATA_NOT_PROVIDED = 'Message data has not been provided';
@@ -7,12 +9,9 @@ export const MESSAGE_QUALIFIER_NOT_PROVIDED = 'Message qualifier has not been pr
 export const INVALID_MESSAGE = 'Message expected to be non empty object';
 export const INVALID_QUALIFIER = 'Qualifier expected to be service/method fomat';
 export const SERVICE_DEFINITION_NOT_PROVIDED = '(serviceDefinition) is not defined';
-export const SERVICE_NAME_NOT_PROVIDED = '(serviceDefinition.serviceName) is not defined';
 export const WRONG_DATA_FORMAT_IN_MESSAGE = 'Message format error: data must be Array';
-export const DEFINITION_MISSING_METHODS = 'Definition missing methods:object';
 export const SERVICES_IS_NOT_ARRAY = 'services is not array';
 export const SERVICE_IS_NOT_OBJECT = 'service is not object';
-export const INVALID_METHODS = 'service definition methods should be non empty object';
 export const MICROSERVICE_OPTIONS_IS_NOT_OBJECT = 'microservice options is not object';
 export const QUALIFIER_IS_NOT_STRING = 'qualifier should be none empty string';
 export const DUPLICATE_PROXY_NAME = 'When createProxies, proxyName must be unique';
@@ -26,28 +25,13 @@ export const getAsyncModelMissmatch = (
   expectedAsyncModel: MicroserviceApi.AsyncModel,
   receivedAsyncModel: MicroserviceApi.AsyncModel
 ) => `asyncModel miss match, expect ${expectedAsyncModel}, but received ${receivedAsyncModel}`;
-export const getIncorrectMethodValueError = (qualifier: string) =>
-  `Method value for ${qualifier} definition should be non empty object`;
-export const getAsynModelNotProvidedError = (qualifier: string) =>
-  `Async model is not provided in service definition for ${qualifier}`;
-export const getInvalidAsyncModelError = (qualifier: string) =>
-  `Invalid async model in service definition for ${qualifier}`;
 export const getMethodNotFoundError = (message: MicroserviceApi.Message) => `Can't find method ${message.qualifier}`;
 export const getInvalidMethodReferenceError = (qualifier: string) =>
   `${qualifier} has valid definition but reference is not a function.`;
 
-export const getServiceNameInvalid = (serviceName: any) =>
-  `serviceName is not valid, must be none empty string but received type ${typeof serviceName}`;
 export const getServiceReferenceNotProvidedError = (serviceName: string) => `${serviceName} reference is not provided`;
 export const getInvalidServiceReferenceError = (serviceName: string) =>
   `${serviceName} reference expected to be an object`;
-export const ASYNC_MODEL_TYPES: {
-  REQUEST_STREAM: MicroserviceApi.RequestStreamAsyncModel;
-  REQUEST_RESPONSE: MicroserviceApi.RequestResponseAsyncModel;
-} = {
-  REQUEST_RESPONSE: 'requestResponse',
-  REQUEST_STREAM: 'requestStream',
-};
 
 export const RSocketConnectionStatus = {
   NOT_CONNECTED: 'NOT_CONNECTED',

--- a/packages/scalecube-microservice/src/helpers/serviceData.ts
+++ b/packages/scalecube-microservice/src/helpers/serviceData.ts
@@ -1,9 +1,8 @@
 import { Observable } from 'rxjs';
 import { takeWhile } from 'rxjs/operators';
 import { DiscoveryApi, MicroserviceApi } from '@scalecube/api';
-import { Qualifier, RemoteRegistry } from './types';
-
-export const getQualifier = ({ serviceName, methodName }: Qualifier) => `${serviceName}/${methodName}`;
+import { RemoteRegistry } from './types';
+export { getQualifier } from '@scalecube/utils';
 
 export const getReferencePointer = ({
   reference,

--- a/packages/scalecube-microservice/src/helpers/serviceData.ts
+++ b/packages/scalecube-microservice/src/helpers/serviceData.ts
@@ -2,7 +2,9 @@ import { Observable } from 'rxjs';
 import { takeWhile } from 'rxjs/operators';
 import { DiscoveryApi, MicroserviceApi } from '@scalecube/api';
 import { RemoteRegistry } from './types';
-export { getQualifier } from '@scalecube/utils';
+
+import { getQualifier } from '@scalecube/utils';
+export { getQualifier };
 
 export const getReferencePointer = ({
   reference,

--- a/packages/scalecube-microservice/src/helpers/types.ts
+++ b/packages/scalecube-microservice/src/helpers/types.ts
@@ -29,8 +29,6 @@ export interface GetProxyOptions {
   serviceDefinition: MicroserviceApi.ServiceDefinition;
 }
 
-export const { Qualifier } = MicroserviceApi.Qualifer;
-
 export interface LocalCallOptions {
   localService: Reference;
   asyncModel: MicroserviceApi.AsyncModel;

--- a/packages/scalecube-microservice/src/helpers/types.ts
+++ b/packages/scalecube-microservice/src/helpers/types.ts
@@ -29,10 +29,7 @@ export interface GetProxyOptions {
   serviceDefinition: MicroserviceApi.ServiceDefinition;
 }
 
-export interface Qualifier {
-  serviceName: string;
-  methodName: string;
-}
+export const { Qualifier } = MicroserviceApi.Qualifer;
 
 export interface LocalCallOptions {
   localService: Reference;

--- a/packages/scalecube-microservice/src/helpers/validation.ts
+++ b/packages/scalecube-microservice/src/helpers/validation.ts
@@ -1,13 +1,11 @@
-import { check, validateAddress } from '@scalecube/utils';
+import { check, validateAddress, validateServiceDefinition } from '@scalecube/utils';
+export { validateServiceDefinition };
 import { MicroserviceApi } from '@scalecube/api';
 import {
   SERVICES_IS_NOT_ARRAY,
   SERVICE_IS_NOT_OBJECT,
   MICROSERVICE_OPTIONS_IS_NOT_OBJECT,
   SERVICE_DEFINITION_NOT_PROVIDED,
-  SERVICE_NAME_NOT_PROVIDED,
-  DEFINITION_MISSING_METHODS,
-  INVALID_METHODS,
   MESSAGE_NOT_PROVIDED,
   WRONG_DATA_FORMAT_IN_MESSAGE,
   QUALIFIER_IS_NOT_STRING,
@@ -15,12 +13,8 @@ import {
   INVALID_MESSAGE,
   MESSAGE_QUALIFIER_NOT_PROVIDED,
   MESSAGE_DATA_NOT_PROVIDED,
-  getServiceNameInvalid,
   ASYNC_MODEL_TYPES,
-  getIncorrectMethodValueError,
   getInvalidMethodReferenceError,
-  getAsynModelNotProvidedError,
-  getInvalidAsyncModelError,
   getInvalidServiceReferenceError,
   getServiceReferenceNotProvidedError,
 } from './constants';
@@ -43,27 +37,6 @@ export const validateService = (service: any) => {
   const { serviceName } = definition;
   check.assertDefined(reference, getServiceReferenceNotProvidedError(serviceName));
   validateServiceReference(reference, definition);
-};
-
-export const validateServiceDefinition = (definition: any) => {
-  check.assertNonEmptyObject(definition);
-  const { serviceName, methods } = definition;
-  check.assertDefined(serviceName, SERVICE_NAME_NOT_PROVIDED);
-  check.assertNonEmptyString(serviceName, getServiceNameInvalid(serviceName));
-  check.assertDefined(methods, DEFINITION_MISSING_METHODS);
-  check.assertNonEmptyObject(methods, INVALID_METHODS);
-  Object.keys(methods).forEach((methodName) => {
-    check.assertNonEmptyString(methodName);
-    const qualifier = getQualifier({ serviceName, methodName });
-    validateAsyncModel(qualifier, methods[methodName]);
-  });
-};
-
-export const validateAsyncModel = (qualifier: string, val: any) => {
-  check.assertNonEmptyObject(val, getIncorrectMethodValueError(qualifier));
-  const { asyncModel } = val;
-  check.assertDefined(asyncModel, getAsynModelNotProvidedError(qualifier));
-  check.assertOneOf(ASYNC_MODEL_TYPES, asyncModel, getInvalidAsyncModelError(qualifier));
 };
 
 export const validateServiceReference = (reference: any, definition: MicroserviceApi.ServiceDefinition) => {

--- a/packages/scalecube-microservice/src/helpers/validation.ts
+++ b/packages/scalecube-microservice/src/helpers/validation.ts
@@ -1,5 +1,4 @@
 import { check, validateAddress, validateServiceDefinition } from '@scalecube/utils';
-export { validateServiceDefinition };
 import { MicroserviceApi } from '@scalecube/api';
 import {
   SERVICES_IS_NOT_ARRAY,

--- a/packages/scalecube-microservice/tests/integration/Errors/createProxies.spec.ts
+++ b/packages/scalecube-microservice/tests/integration/Errors/createProxies.spec.ts
@@ -9,16 +9,18 @@
 import { ASYNC_MODEL_TYPES, createMicroservice } from '../../../src';
 import { MicroserviceApi } from '@scalecube/api';
 
-import {
+import { DUPLICATE_PROXY_NAME } from '../../../src/helpers/constants';
+
+import { greetingServiceDefinition } from '../../mocks/GreetingService';
+import { constants as utilsConstants } from '@scalecube/utils';
+
+const {
   DEFINITION_MISSING_METHODS,
   INVALID_METHODS,
   SERVICE_NAME_NOT_PROVIDED,
   getIncorrectMethodValueError,
   getServiceNameInvalid,
-  DUPLICATE_PROXY_NAME,
-} from '../../../src/helpers/constants';
-
-import { greetingServiceDefinition } from '../../mocks/GreetingService';
+} = utilsConstants;
 
 describe('validation test for create proxy from microservice', () => {
   const ms = createMicroservice({});
@@ -156,7 +158,7 @@ describe('validation test for create proxy from microservice', () => {
   );
 
   // @ts-ignore
-  test.each([[], 'methods', true, false, 10, null, undefined, Symbol(), new (class {})()])(
+  test.each([[], 'methods', true, false, 10, null, undefined, Symbol(), new class {}()])(
     `
     Scenario: serviceDefinition with invalid 'asyncModel' value
     Given     a 'asyncModel'

--- a/packages/scalecube-microservice/tests/integration/Errors/createProxy.spec.ts
+++ b/packages/scalecube-microservice/tests/integration/Errors/createProxy.spec.ts
@@ -7,13 +7,15 @@
  *    Check validity - proxy - serviceDefinition asyncModel value      - https://github.com/scalecube/scalecube-js/issues/103
  *****/
 import { createMicroservice } from '../../../src';
-import {
+import { constants as utilsConstants } from '@scalecube/utils';
+
+const {
   DEFINITION_MISSING_METHODS,
   INVALID_METHODS,
   SERVICE_NAME_NOT_PROVIDED,
   getIncorrectMethodValueError,
   getServiceNameInvalid,
-} from '../../../src/helpers/constants';
+} = utilsConstants;
 
 describe('validation test for create proxy from microservice', () => {
   const ms = createMicroservice({});
@@ -130,7 +132,7 @@ describe('validation test for create proxy from microservice', () => {
   );
 
   // @ts-ignore
-  test.each([[], 'methods', true, false, 10, null, undefined, Symbol(), new (class {})()])(
+  test.each([[], 'methods', true, false, 10, null, undefined, Symbol(), new class {}()])(
     `
     Scenario: serviceDefinition with invalid 'asyncModel' value
     Given     a 'asyncModel'

--- a/packages/scalecube-microservice/tests/integration/Errors/microservices-create.spec.ts
+++ b/packages/scalecube-microservice/tests/integration/Errors/microservices-create.spec.ts
@@ -8,18 +8,22 @@ import { constants } from '@scalecube/utils';
 import { ASYNC_MODEL_TYPES, createMicroservice } from '../../../src';
 import {
   getInvalidMethodReferenceError,
-  getIncorrectMethodValueError,
-  getInvalidAsyncModelError,
-  DEFINITION_MISSING_METHODS,
-  getServiceNameInvalid,
   SERVICES_IS_NOT_ARRAY,
   SERVICE_IS_NOT_OBJECT,
-  SERVICE_NAME_NOT_PROVIDED,
-  getAsynModelNotProvidedError,
   getInvalidServiceReferenceError,
   getServiceReferenceNotProvidedError,
 } from '../../../src/helpers/constants';
 import { getQualifier } from '../../../src/helpers/serviceData';
+import { constants as utilsConstants } from '@scalecube/utils';
+
+const {
+  getIncorrectMethodValueError,
+  getInvalidAsyncModelError,
+  DEFINITION_MISSING_METHODS,
+  getServiceNameInvalid,
+  SERVICE_NAME_NOT_PROVIDED,
+  getAsynModelNotProvidedError,
+} = utilsConstants;
 
 describe('Test the creation of Microservice', () => {
   const baseServiceDefinition = {

--- a/packages/scalecube-microservice/tests/integration/multiple-proxies.spec.ts
+++ b/packages/scalecube-microservice/tests/integration/multiple-proxies.spec.ts
@@ -1,9 +1,11 @@
 import { createMicroservice, ASYNC_MODEL_TYPES } from '../../src';
 import { hello, greet$ } from '../mocks/GreetingService';
 import { Observable } from 'rxjs';
-import { getServiceNameInvalid } from '../../src/helpers/constants';
 import { MicroserviceApi } from '@scalecube/api';
 import { getAddress } from '@scalecube/utils';
+import { constants as utilsConstants } from '@scalecube/utils';
+
+const { getServiceNameInvalid } = utilsConstants;
 
 describe(`
      Background: Resolve createProxies ONLY when the service available in the registry

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,5 +1,28 @@
+import { MicroserviceApi } from '@scalecube/api';
+
 export const NOT_VALID_PROTOCOL = 'Not a valid protocol';
 export const NOT_VALID_ADDRESS = 'Address must be of type object';
 export const NOT_VALID_HOST = 'Not a valid host';
 export const NOT_VALID_PATH = 'Not a valid path';
 export const NOT_VALID_PORT = 'Not a valid port';
+
+export const ASYNC_MODEL_TYPES: {
+  REQUEST_STREAM: MicroserviceApi.RequestStreamAsyncModel;
+  REQUEST_RESPONSE: MicroserviceApi.RequestResponseAsyncModel;
+} = {
+  REQUEST_RESPONSE: 'requestResponse',
+  REQUEST_STREAM: 'requestStream',
+};
+
+export const SERVICE_NAME_NOT_PROVIDED = '(serviceDefinition.serviceName) is not defined';
+export const DEFINITION_MISSING_METHODS = 'Definition missing methods:object';
+export const INVALID_METHODS = 'service definition methods should be non empty object';
+export const getServiceNameInvalid = (serviceName: any) =>
+  `serviceName is not valid, must be none empty string but received type ${typeof serviceName}`;
+
+export const getIncorrectMethodValueError = (qualifier: string) =>
+  `Method value for ${qualifier} definition should be non empty object`;
+export const getAsynModelNotProvidedError = (qualifier: string) =>
+  `Async model is not provided in service definition for ${qualifier}`;
+export const getInvalidAsyncModelError = (qualifier: string) =>
+  `Invalid async model in service definition for ${qualifier}`;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -4,7 +4,20 @@ import * as constants from './constants';
 import { addWorker, removeWorker } from './connectWorkers';
 import { saveToLogs } from './logs';
 import { isNodejs } from './checkEnvironemnt';
+import { validateServiceDefinition } from './serviceDefinition';
+import { getQualifier } from './qualifier';
 
 const workers = !isNodejs() ? { addWorker, removeWorker } : {};
 
-export { check, getFullAddress, validateAddress, constants, getAddress, workers, saveToLogs, isNodejs };
+export {
+  check,
+  getFullAddress,
+  validateAddress,
+  constants,
+  getAddress,
+  workers,
+  saveToLogs,
+  isNodejs,
+  validateServiceDefinition,
+  getQualifier,
+};

--- a/packages/utils/src/qualifier.ts
+++ b/packages/utils/src/qualifier.ts
@@ -1,0 +1,4 @@
+import { MicroserviceApi } from '@scalecube/api';
+
+export const getQualifier = ({ serviceName, methodName }: MicroserviceApi.Qualifier): string =>
+  `${serviceName}/${methodName}`;

--- a/packages/utils/src/serviceDefinition.ts
+++ b/packages/utils/src/serviceDefinition.ts
@@ -1,0 +1,33 @@
+import * as check from './check';
+import { getQualifier } from './qualifier';
+import {
+  SERVICE_NAME_NOT_PROVIDED,
+  DEFINITION_MISSING_METHODS,
+  INVALID_METHODS,
+  ASYNC_MODEL_TYPES,
+  getServiceNameInvalid,
+  getIncorrectMethodValueError,
+  getAsynModelNotProvidedError,
+  getInvalidAsyncModelError,
+} from './constants';
+
+export const validateServiceDefinition = (definition: any) => {
+  check.assertNonEmptyObject(definition);
+  const { serviceName, methods } = definition;
+  check.assertDefined(serviceName, SERVICE_NAME_NOT_PROVIDED);
+  check.assertNonEmptyString(serviceName, getServiceNameInvalid(serviceName));
+  check.assertDefined(methods, DEFINITION_MISSING_METHODS);
+  check.assertNonEmptyObject(methods, INVALID_METHODS);
+  Object.keys(methods).forEach((methodName) => {
+    check.assertNonEmptyString(methodName);
+    const qualifier = getQualifier({ serviceName, methodName });
+    validateAsyncModel(qualifier, methods[methodName]);
+  });
+};
+
+export const validateAsyncModel = (qualifier: string, val: any) => {
+  check.assertNonEmptyObject(val, getIncorrectMethodValueError(qualifier));
+  const { asyncModel } = val;
+  check.assertDefined(asyncModel, getAsynModelNotProvidedError(qualifier));
+  check.assertOneOf(ASYNC_MODEL_TYPES, asyncModel, getInvalidAsyncModelError(qualifier));
+};


### PR DESCRIPTION
Add possibility to create multiple proxies for several services that uses same rsocket connection simultaneously
```
[proxyA, proxyB] = await createGatewayProxy('ws://localhost:8080', [definitionA, definitionB])
```