### PR TITLE
Use exact same version of @scalecube/*

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,10 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*"],
+  "command": {
+    "version": {
+      "exact": true
+    }
+  },
   "version": "0.2.10"
 }

--- a/packages/examples/k8s/consumer.js
+++ b/packages/examples/k8s/consumer.js
@@ -18,13 +18,13 @@ const proxy = createMicroservice({
   seedAddress: {
     protocol: 'ws',
     host: process.env.SEED,
-    port: 8080,
+    port: 7001,
     path: '',
   },
   address: {
     protocol: 'ws',
     host: process.env.ADDRESS,
-    port: 8080,
+    port: 7002,
     path: '',
   },
   debug: true,

--- a/packages/examples/k8s/greeting.js
+++ b/packages/examples/k8s/greeting.js
@@ -7,13 +7,13 @@ createMicroservice({
   seedAddress: {
     protocol: 'ws',
     host: process.env.SEED,
-    port: 8080,
+    port: 7001,
     path: '',
   },
   address: {
     protocol: 'ws',
     host: process.env.ADDRESS,
-    port: 8080,
+    port: 7003,
     path: '',
   },
   services: [

--- a/packages/examples/k8s/seed.js
+++ b/packages/examples/k8s/seed.js
@@ -7,7 +7,7 @@ createMicroservice({
   address: {
     protocol: 'ws',
     host: process.env.ADDRESS,
-    port: 8080,
+    port: 7001,
     path: '',
   },
   debug: true,


### PR DESCRIPTION
Lerna config by default to use newer than (^version), this causes a problem with snapshots versions