### PR TITLE
0.2.11

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "exact": true
     }
   },
-  "version": "0.2.10"
+  "version": "0.2.11"
 }

--- a/packages/addressable/package.json
+++ b/packages/addressable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/addressable",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "unpkg": "dist/index.js",
   "main": "lib/index.js",
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^5.0.2",
-    "@scalecube/utils": "0.2.10",
+    "@scalecube/utils": "0.2.11",
     "@types/expect-puppeteer": "^4.4.3",
     "@types/jest-environment-puppeteer": "^4.3.2",
     "@types/puppeteer": "^3.0.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/api",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/browser",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "unpkg": "dist/index.js",
   "main": "lib/index.js",
@@ -40,12 +40,12 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "0.2.10",
-    "@scalecube/cluster-browser": "0.2.10",
-    "@scalecube/routers": "0.2.10",
-    "@scalecube/scalecube-microservice": "0.2.10",
-    "@scalecube/transport-browser": "0.2.10",
-    "@scalecube/utils": "0.2.10",
+    "@scalecube/api": "0.2.11",
+    "@scalecube/cluster-browser": "0.2.11",
+    "@scalecube/routers": "0.2.11",
+    "@scalecube/scalecube-microservice": "0.2.11",
+    "@scalecube/transport-browser": "0.2.11",
+    "@scalecube/utils": "0.2.11",
     "rxjs": "^6.4.0"
   }
 }

--- a/packages/cluster-browser/package.json
+++ b/packages/cluster-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/cluster-browser",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "cjs/index.js",
   "module": "es/index.js",
@@ -31,9 +31,9 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "0.2.10",
-    "@scalecube/utils": "0.2.10",
-    "@scalecube/addressable": "0.2.10",
+    "@scalecube/addressable": "0.2.11",
+    "@scalecube/api": "0.2.11",
+    "@scalecube/utils": "0.2.11",
     "rxjs": "^6.4.0"
   }
 }

--- a/packages/cluster-nodejs/package.json
+++ b/packages/cluster-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/cluster-nodejs",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "0.2.10",
-    "@scalecube/utils": "0.2.10",
+    "@scalecube/api": "0.2.11",
+    "@scalecube/utils": "0.2.11",
     "rxjs": "^6.4.0",
     "swim": "^0.6.0"
   }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/examples",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "rollup": "rollup/index.js",
   "license": "MIT",
@@ -38,12 +38,12 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "^0.2.10",
-    "@scalecube/browser": "^0.2.10",
-    "@scalecube/node": "^0.2.10",
-    "@scalecube/routers": "^0.2.10",
-    "@scalecube/transport-nodejs": "^0.2.10",
-    "@scalecube/utils": "^0.2.10"
+    "@scalecube/api": "0.2.11",
+    "@scalecube/browser": "0.2.11",
+    "@scalecube/node": "0.2.11",
+    "@scalecube/routers": "0.2.11",
+    "@scalecube/transport-nodejs": "0.2.11",
+    "@scalecube/utils": "0.2.11"
   },
   "browserslist": [
     "ie 11",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/node",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -27,12 +27,12 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "0.2.10",
-    "@scalecube/cluster-nodejs": "0.2.10",
-    "@scalecube/routers": "0.2.10",
-    "@scalecube/scalecube-microservice": "0.2.10",
-    "@scalecube/transport-nodejs": "0.2.10",
-    "@scalecube/utils": "0.2.10",
+    "@scalecube/api": "0.2.11",
+    "@scalecube/cluster-nodejs": "0.2.11",
+    "@scalecube/routers": "0.2.11",
+    "@scalecube/scalecube-microservice": "0.2.11",
+    "@scalecube/transport-nodejs": "0.2.11",
+    "@scalecube/utils": "0.2.11",
     "rxjs": "^6.4.0"
   }
 }

--- a/packages/routers/package.json
+++ b/packages/routers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/routers",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "cjs/index.js",
   "module": "es/index.js",
@@ -30,7 +30,7 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "0.2.10",
-    "@scalecube/utils": "0.2.10"
+    "@scalecube/api": "0.2.11",
+    "@scalecube/utils": "0.2.11"
   }
 }

--- a/packages/rsocket-adapter/package.json
+++ b/packages/rsocket-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/rsocket-adapter",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "cjs/index.js",
   "module": "es/index.js",
@@ -31,8 +31,8 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "0.2.10",
-    "@scalecube/utils": "0.2.10",
+    "@scalecube/api": "0.2.11",
+    "@scalecube/utils": "0.2.11",
     "rsocket-core": "^0.0.16",
     "rsocket-flowable": "^0.0.14",
     "rsocket-types": "^0.0.16",

--- a/packages/rsocket-ws-gateway-client/package.json
+++ b/packages/rsocket-ws-gateway-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/rsocket-ws-gateway-client",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -34,7 +34,7 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/utils": "0.2.10",
+    "@scalecube/utils": "0.2.11",
     "rsocket-core": "^0.0.16",
     "rsocket-flowable": "^0.0.14",
     "rsocket-websocket-client": "^0.0.16",

--- a/packages/rsocket-ws-gateway/package.json
+++ b/packages/rsocket-ws-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/rsocket-ws-gateway",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -21,8 +21,8 @@
   },
   "author": "Scalecube (https://github.com/scalecube/scalecube-js)",
   "devDependencies": {
-    "@scalecube/browser": "0.2.10",
-    "@scalecube/rsocket-ws-gateway-client": "0.2.10",
+    "@scalecube/browser": "0.2.11",
+    "@scalecube/rsocket-ws-gateway-client": "0.2.11",
     "jest": "^24.6.0",
     "rollup": "^1.14.6",
     "rollup-plugin-babel": "^4.3.3",
@@ -35,8 +35,8 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "^0.2.10",
-    "@scalecube/utils": "^0.2.10",
+    "@scalecube/api": "0.2.11",
+    "@scalecube/utils": "0.2.11",
     "rsocket-core": "^0.0.16",
     "rsocket-flowable": "^0.0.14",
     "rsocket-websocket-client": "^0.0.16",

--- a/packages/scalecube-discovery/package.json
+++ b/packages/scalecube-discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/scalecube-discovery",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "cjs/index.js",
   "module": "es/index.js",
@@ -23,7 +23,7 @@
   "author": "Scalecube (https://github.com/scalecube/scalecube-js)",
   "devDependencies": {
     "@babel/core": "^7.4.5",
-    "@scalecube/cluster-browser": "0.2.10",
+    "@scalecube/cluster-browser": "0.2.11",
     "jest": "^24.6.0",
     "rollup": "^1.14.6",
     "rollup-plugin-babel": "^4.3.3",
@@ -38,8 +38,8 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "0.2.10",
-    "@scalecube/utils": "0.2.10",
+    "@scalecube/api": "0.2.11",
+    "@scalecube/utils": "0.2.11",
     "rxjs": "^6.4.0"
   }
 }

--- a/packages/scalecube-microservice/package.json
+++ b/packages/scalecube-microservice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/scalecube-microservice",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -30,9 +30,9 @@
     }
   },
   "devDependencies": {
-    "@scalecube/cluster-browser": "0.2.10",
-    "@scalecube/routers": "0.2.10",
-    "@scalecube/transport-browser": "0.2.10",
+    "@scalecube/cluster-browser": "0.2.11",
+    "@scalecube/routers": "0.2.11",
+    "@scalecube/transport-browser": "0.2.11",
     "jest": "^24.6.0",
     "rollup": "^1.14.6",
     "rollup-plugin-babel": "^4.3.3",
@@ -48,9 +48,9 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "0.2.10",
-    "@scalecube/scalecube-discovery": "0.2.10",
-    "@scalecube/utils": "0.2.10",
+    "@scalecube/api": "0.2.11",
+    "@scalecube/scalecube-discovery": "0.2.11",
+    "@scalecube/utils": "0.2.11",
     "rxjs": "^6.4.0"
   }
 }

--- a/packages/transport-browser/package.json
+++ b/packages/transport-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/transport-browser",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "cjs/index.js",
   "module": "es/index.js",
@@ -31,10 +31,10 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "0.2.10",
-    "@scalecube/rsocket-adapter": "0.2.10",
-    "@scalecube/addressable": "0.2.10",
-    "@scalecube/utils": "0.2.10",
+    "@scalecube/addressable": "0.2.11",
+    "@scalecube/api": "0.2.11",
+    "@scalecube/rsocket-adapter": "0.2.11",
+    "@scalecube/utils": "0.2.11",
     "rsocket-core": "^0.0.16",
     "rsocket-events-client": "^0.0.22",
     "rsocket-events-server": "^0.0.22",

--- a/packages/transport-nodejs/package.json
+++ b/packages/transport-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/transport-nodejs",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -33,9 +33,9 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@scalecube/api": "0.2.10",
-    "@scalecube/rsocket-adapter": "0.2.10",
-    "@scalecube/utils": "0.2.10",
+    "@scalecube/api": "0.2.11",
+    "@scalecube/rsocket-adapter": "0.2.11",
+    "@scalecube/utils": "0.2.11",
     "rsocket-core": "^0.0.16",
     "rsocket-tcp-client": "^0.0.16",
     "rsocket-tcp-server": "^0.0.16",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalecube/utils",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": false,
   "main": "cjs/index.js",
   "module": "es/index.js",
@@ -21,7 +21,7 @@
   },
   "author": "Scalecube (https://github.com/scalecube/scalecube-js)",
   "dependencies": {
-    "@scalecube/api": "0.2.10"
+    "@scalecube/api": "0.2.11"
   },
   "devDependencies": {
     "jest": "^24.6.0",


### PR DESCRIPTION
#### :rocket: Enhancements
- Amount of endpoints that can be registered on node-cluster was increased (#272)
- Allow seeds inside IFrame, before it was possible only on the main thread. This change was done mainly for sandboxes (like this example https://codesandbox.io/s/scalecube-js-tutorial-bwtl7) and embed widget  (#256)
- New package for RSocket Gateway Client (split server/client)(#284)

#### :bug: Bug Fix
- Added missing dependency rxjs for @scalecube/api (#257)
- Unsubscribe (from serviceCall or Gateway) not canceling serviceCall and from the service (#265)
- GetAddress util when path is empty, port swap with path (#275)

#### :zap: Performance
- Decreased bundle size for browsers

| Version | Type            | Bundle Size | Minified Size | Gzipped Size |
|------------|-----------------|------------------|-------------------|-------------------|
| 0.2.9     | CommonJS | 307.72 KB    | 125.77 KB     | 29.4 KB         |
| 0.2.9     | IFFE            | 123.94 KB    | 123.25 KB     | 29.14 KB       |
| 0.2.10   | CommonJS | 177.02 KB    | 85.33 KB       | 20.32 KB       |
| 0.2.10   | IFFE            | 197.25 KB    | 79.14 KB       | 20.57 KB       |

#### :memo: Documentation
- What is SC + CodeSandbox
- Update readme (#258) 
- Fix examples in readme (#266)
- Change links to documentation in readmes (#274)

#### :house: Internal
- Use exact same version of @scalecube/* #294
- node-cluster metadata was limited to 512 bytes, increased to 4096 (#272)
- Publish endpoints with data format optimized for size (#272)
- Addressable post messages. (#259)
- Refactor cluster to use addressable (#261)
- transport browser rewrite (#263)
- Dependencies security updates (#258)(#268)(#267)(#271)(#274)(#276)(#277)(#278)(#279)(#280)(#281)(#282)(#283)(#285)(#287)(#288)(#289)